### PR TITLE
ubi7 instead of ubi8

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0-208
+FROM registry.access.redhat.com/ubi7/ubi-minimal:7.7-138
 
 ENV OPERATOR=/usr/local/bin/ibm-block-csi-operator \
     USER_UID=1001 \

--- a/build/Dockerfile.operator
+++ b/build/Dockerfile.operator
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build \
 	github.com/IBM/ibm-block-csi-operator/cmd/manager
 
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0-213
+FROM registry.access.redhat.com/ubi7/ubi-minimal:7.7-138
 MAINTAINER IBM Storage
 
 ###Required Labels


### PR DESCRIPTION
**update to UBI7 base image**
Per Redhat support matrix([HERE](https://access.redhat.com/support/policy/rhel-container-compatibility)), since CSI GA v1 support RHEL7.x worker nodes, then the related UBI image of the CSI container must be ubi7 and not ubi8.

So this PR change the node and controller base image
operator -> ubi7/ubi-minimal:7.7-138  (instead of ubi8/ubi-minimal:8.0-213)
https://access.redhat.com/containers/#/registry.access.redhat.com/ubi7/ubi-minimal

Note: node agent was not updated since its not active for v1.0.0.

Similar PR on the driver side of thing -> https://github.com/IBM/ibm-block-csi-driver/pull/91