### PR TITLE
Feature/csi 548 csi driver linter fix

### DIFF
--- a/pkg/controller/ibmblockcsi/syncer/csi_controller.go
+++ b/pkg/controller/ibmblockcsi/syncer/csi_controller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/imdario/mergo"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -57,6 +58,7 @@ func NewCSIControllerSyncer(c client.Client, scheme *runtime.Scheme, driver *ibm
 			Name:        config.GetNameForResource(config.CSIController, driver.Name),
 			Namespace:   driver.Namespace,
 			Annotations: driver.GetAnnotations(),
+			Labels:      driver.GetLabels(),
 		},
 	}
 
@@ -73,11 +75,12 @@ func NewCSIControllerSyncer(c client.Client, scheme *runtime.Scheme, driver *ibm
 func (s *csiControllerSyncer) SyncFn() error {
 	out := s.obj.(*appsv1.StatefulSet)
 
-	out.Spec.Selector = metav1.SetAsLabelSelector(s.driver.GetCSIControllerComponentAnnotations())
+	out.Spec.Selector = metav1.SetAsLabelSelector(s.driver.GetCSIControllerSelectorLabels())
 	out.Spec.ServiceName = config.GetNameForResource(config.CSIController, s.driver.Name)
 
 	// ensure template
-	out.Spec.Template.ObjectMeta.Labels = s.driver.GetCSIControllerComponentAnnotations()
+	out.Spec.Template.ObjectMeta.Labels = s.driver.GetCSIControllerPodLabels()
+	out.Spec.Template.ObjectMeta.Annotations = s.driver.GetAnnotations()
 
 	err := mergo.Merge(&out.Spec.Template.Spec, s.ensurePodSpec(), mergo.WithTransformers(transformers.PodSpec))
 	if err != nil {
@@ -96,6 +99,9 @@ func (s *csiControllerSyncer) ensurePodSpec() corev1.PodSpec {
 			FSGroup:   &fsGroup,
 			RunAsUser: &fsGroup,
 		},
+		Affinity: &corev1.Affinity{
+			NodeAffinity: ensureNodeAffinity(),
+		},
 		ServiceAccountName: config.GetNameForResource(config.CSIControllerServiceAccount, s.driver.Name),
 	}
 }
@@ -112,14 +118,6 @@ func (s *csiControllerSyncer) ensureContainersSpec() []corev1.Container {
 	})
 
 	//controllerPlugin.Resources = ensureResources(controllerContainerName)
-
-	controllerPlugin.LivenessProbe = ensureProbe(10, 3, 2, corev1.Handler{
-		HTTPGet: &corev1.HTTPGetAction{
-			Path:   "/healthz",
-			Port:   controllerContainerHealthPort,
-			Scheme: corev1.URISchemeHTTP,
-		},
-	})
 
 	// cluster driver registrar sidecar
 	registrar := s.ensureContainer(controllerDriverRegistrarContainerName,
@@ -157,15 +155,64 @@ func (s *csiControllerSyncer) ensureContainersSpec() []corev1.Container {
 	}
 }
 
+func ensureDefaultResources() corev1.ResourceRequirements {
+	return ensureResources("50m", "100m", "50Mi", "100Mi")
+}
+
+func ensureResources(cpuRequests, cpuLimits, memoryRequests, memoryLimits string) corev1.ResourceRequirements {
+	requests := corev1.ResourceList{
+		corev1.ResourceRequestsCPU:    resource.MustParse(cpuRequests),
+		corev1.ResourceRequestsMemory: resource.MustParse(memoryRequests),
+	}
+	limits := corev1.ResourceList{
+		corev1.ResourceLimitsCPU:    resource.MustParse(cpuLimits),
+		corev1.ResourceLimitsMemory: resource.MustParse(memoryLimits),
+	}
+
+	return corev1.ResourceRequirements{
+		Limits:   limits,
+		Requests: requests,
+	}
+}
+
+func ensureNodeAffinity() *corev1.NodeAffinity {
+	return &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "beta.kubernetes.io/arch",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"amd64"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func (s *csiControllerSyncer) ensureContainer(name, image string, args []string) corev1.Container {
+	sc := &corev1.SecurityContext{}
+	fillSecurityContextCapabilities(sc)
 	return corev1.Container{
 		Name:            name,
 		Image:           image,
 		ImagePullPolicy: "IfNotPresent",
 		Args:            args,
 		//EnvFrom:         s.getEnvSourcesFor(name),
-		Env:          s.getEnvFor(name),
-		VolumeMounts: s.getVolumeMountsFor(name),
+		Env:             s.getEnvFor(name),
+		VolumeMounts:    s.getVolumeMountsFor(name),
+		SecurityContext: sc,
+		Resources:       ensureDefaultResources(),
+		LivenessProbe: ensureProbe(10, 3, 2, corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   "/healthz",
+				Port:   controllerContainerHealthPort,
+				Scheme: corev1.URISchemeHTTP,
+			},
+		}),
 	}
 }
 

--- a/pkg/controller/ibmblockcsi/syncer/csi_controller.go
+++ b/pkg/controller/ibmblockcsi/syncer/csi_controller.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/IBM/ibm-block-csi-operator/pkg/config"
 	"github.com/IBM/ibm-block-csi-operator/pkg/internal/ibmblockcsi"
+	"github.com/IBM/ibm-block-csi-operator/pkg/util/boolptr"
 	"github.com/presslabs/controller-util/mergo/transformers"
 	"github.com/presslabs/controller-util/syncer"
 )
@@ -182,7 +183,7 @@ func ensureNodeAffinity() *corev1.NodeAffinity {
 				{
 					MatchExpressions: []corev1.NodeSelectorRequirement{
 						{
-							Key:      "beta.kubernetes.io/arch",
+							Key:      "kubernetes.io/arch",
 							Operator: corev1.NodeSelectorOpIn,
 							Values:   []string{"amd64"},
 						},
@@ -194,7 +195,7 @@ func ensureNodeAffinity() *corev1.NodeAffinity {
 }
 
 func (s *csiControllerSyncer) ensureContainer(name, image string, args []string) corev1.Container {
-	sc := &corev1.SecurityContext{}
+	sc := &corev1.SecurityContext{AllowPrivilegeEscalation: boolptr.False()}
 	fillSecurityContextCapabilities(sc)
 	return corev1.Container{
 		Name:            name,

--- a/pkg/controller/ibmblockcsi/syncer/csi_node.go
+++ b/pkg/controller/ibmblockcsi/syncer/csi_node.go
@@ -119,9 +119,18 @@ func (s *csiNodeSyncer) ensureContainersSpec() []corev1.Container {
 	})
 
 	nodePlugin.SecurityContext = &corev1.SecurityContext{
-		Privileged: boolptr.True(),
+		Privileged:               boolptr.True(),
+		AllowPrivilegeEscalation: boolptr.True(),
 	}
-	fillSecurityContextCapabilities(nodePlugin.SecurityContext)
+	fillSecurityContextCapabilities(
+		nodePlugin.SecurityContext,
+		"CHOWN",
+		"FSETID",
+		"FOWNER",
+		"SETGID",
+		"SETUID",
+		"DAC_OVERRIDE",
+	)
 
 	//nodePlugin.Resources = ensureResources(nodeContainerName)
 
@@ -141,7 +150,7 @@ func (s *csiNodeSyncer) ensureContainersSpec() []corev1.Container {
 			},
 		},
 	}
-	registrar.SecurityContext = &corev1.SecurityContext{}
+	registrar.SecurityContext = &corev1.SecurityContext{AllowPrivilegeEscalation: boolptr.False()}
 	fillSecurityContextCapabilities(registrar.SecurityContext)
 
 	// liveness probe sidecar
@@ -151,7 +160,7 @@ func (s *csiNodeSyncer) ensureContainersSpec() []corev1.Container {
 			"--csi-address=/csi/csi.sock",
 		},
 	)
-	livenessProbe.SecurityContext = &corev1.SecurityContext{}
+	livenessProbe.SecurityContext = &corev1.SecurityContext{AllowPrivilegeEscalation: boolptr.False()}
 	fillSecurityContextCapabilities(livenessProbe.SecurityContext)
 
 	return []corev1.Container{

--- a/pkg/internal/ibmblockcsi/ibmblockcsi.go
+++ b/pkg/internal/ibmblockcsi/ibmblockcsi.go
@@ -47,6 +47,7 @@ func (c *IBMBlockCSI) GetLabels() labels.Set {
 	labels := labels.Set{
 		"app.kubernetes.io/name":       config.ProductName,
 		"app.kubernetes.io/instance":   c.Name,
+		"app.kubernetes.io/version":    csiversion.Version,
 		"app.kubernetes.io/managed-by": config.Name,
 	}
 

--- a/pkg/internal/ibmblockcsi/ibmblockcsi.go
+++ b/pkg/internal/ibmblockcsi/ibmblockcsi.go
@@ -42,52 +42,65 @@ func (c *IBMBlockCSI) Unwrap() *csiv1.IBMBlockCSI {
 	return c.IBMBlockCSI
 }
 
-// GetAnnotations returns all the annotations to be set on all resources
-func (c *IBMBlockCSI) GetAnnotations() labels.Set {
+// GetLabels returns all the labels to be set on all resources
+func (c *IBMBlockCSI) GetLabels() labels.Set {
 	labels := labels.Set{
 		"app.kubernetes.io/name":       config.ProductName,
 		"app.kubernetes.io/instance":   c.Name,
-		"app.kubernetes.io/version":    csiversion.Version,
 		"app.kubernetes.io/managed-by": config.Name,
 	}
 
-	if c.Annotations != nil {
-		for k, v := range c.Annotations {
-			labels[k] = v
+	if c.Labels != nil {
+		for k, v := range c.Labels {
+			if !labels.Has(k) {
+				labels[k] = v
+			}
 		}
 	}
 
 	return labels
 }
 
-func (c *IBMBlockCSI) GetComponentAnnotations(component string) labels.Set {
+// GetAnnotations returns all the annotations to be set on all resources
+func (c *IBMBlockCSI) GetAnnotations() labels.Set {
+	labels := labels.Set{
+		"productID":      config.ProductName,
+		"productName":    config.ProductName,
+		"productVersion": csiversion.Version,
+	}
+
+	if c.Annotations != nil {
+		for k, v := range c.Annotations {
+			if !labels.Has(k) {
+				labels[k] = v
+			}
+		}
+	}
+
+	return labels
+}
+
+// GetSelectorLabels returns labels used in label selectors
+func (c *IBMBlockCSI) GetSelectorLabels(component string) labels.Set {
 	return labels.Set{
 		"app.kubernetes.io/component": component,
 	}
 }
 
-func (c *IBMBlockCSI) GetCSIControllerComponentAnnotations() labels.Set {
-	return c.GetComponentAnnotations(config.CSIController.String())
+func (c *IBMBlockCSI) GetCSIControllerSelectorLabels() labels.Set {
+	return c.GetSelectorLabels(config.CSIController.String())
 }
 
-func (c *IBMBlockCSI) GetCSINodeComponentAnnotations() labels.Set {
-	return c.GetComponentAnnotations(config.CSINode.String())
+func (c *IBMBlockCSI) GetCSINodeSelectorLabels() labels.Set {
+	return c.GetSelectorLabels(config.CSINode.String())
 }
 
-func (c *IBMBlockCSI) GetCSIControllerAnnotations() labels.Set {
-	labels := c.GetLabels()
-	for k, v := range c.GetCSIControllerComponentAnnotations() {
-		labels[k] = v
-	}
-	return labels
+func (c *IBMBlockCSI) GetCSIControllerPodLabels() labels.Set {
+	return labels.Merge(c.GetLabels(), c.GetCSIControllerSelectorLabels())
 }
 
-func (c *IBMBlockCSI) GetCSINodeAnnotations() labels.Set {
-	labels := c.GetLabels()
-	for k, v := range c.GetCSINodeComponentAnnotations() {
-		labels[k] = v
-	}
-	return labels
+func (c *IBMBlockCSI) GetCSINodePodLabels() labels.Set {
+	return labels.Merge(c.GetLabels(), c.GetCSINodeSelectorLabels())
 }
 
 func (c *IBMBlockCSI) GetCSIControllerImage() string {

--- a/pkg/internal/ibmblockcsi/static_resource_generator.go
+++ b/pkg/internal/ibmblockcsi/static_resource_generator.go
@@ -28,6 +28,7 @@ func (c *IBMBlockCSI) GenerateControllerServiceAccount() *corev1.ServiceAccount 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.GetNameForResource(config.CSIControllerServiceAccount, c.Name),
 			Namespace: c.Namespace,
+			Labels:    c.GetLabels(),
 		},
 	}
 }


### PR DESCRIPTION
1. add required labels and annotations
2. add node affinity
3. add liveness probe for all containers
4. add cpu/mermory requests and limits
5. set default security context (drop all, add nothing)