### PR TITLE
remove HostNetwork:true and DNSpolicy on csi node

### DIFF
--- a/pkg/controller/config/syncer/node_agent.go
+++ b/pkg/controller/config/syncer/node_agent.go
@@ -92,6 +92,8 @@ func (s *nodeAgentSyncer) ensurePodSpec() corev1.PodSpec {
 	return corev1.PodSpec{
 		Containers:  s.ensureContainersSpec(),
 		Volumes:     s.ensureVolumes(),
+		HostNetwork: true,
+		DNSPolicy:   "ClusterFirstWithHostNet", // To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'
 	}
 }
 

--- a/pkg/controller/config/syncer/node_agent.go
+++ b/pkg/controller/config/syncer/node_agent.go
@@ -92,8 +92,6 @@ func (s *nodeAgentSyncer) ensurePodSpec() corev1.PodSpec {
 	return corev1.PodSpec{
 		Containers:  s.ensureContainersSpec(),
 		Volumes:     s.ensureVolumes(),
-		HostNetwork: true,
-		DNSPolicy:   "ClusterFirstWithHostNet", // To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'
 	}
 }
 

--- a/pkg/controller/ibmblockcsi/syncer/csi_node.go
+++ b/pkg/controller/ibmblockcsi/syncer/csi_node.go
@@ -93,8 +93,6 @@ func (s *csiNodeSyncer) ensurePodSpec() corev1.PodSpec {
 	return corev1.PodSpec{
 		Containers:         s.ensureContainersSpec(),
 		Volumes:            s.ensureVolumes(),
-		HostNetwork:        true,
-		DNSPolicy:          "ClusterFirstWithHostNet", // To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'
 		ServiceAccountName: "default",
 		Affinity: &corev1.Affinity{
 			NodeAffinity: ensureNodeAffinity(),


### PR DESCRIPTION
Openshift certification indicates that pod.spec.hostNetwork:true on the csi node is not recommended.
I tested it without hostNetwor:true (which means its by default false) and it works well (tested it via the original yamls in the driver PR -> https://github.com/IBM/ibm-block-csi-driver/pull/94).

Since hostNetwork dropped then we can also drop the DNSpolicy setting as well.
