### PR TITLE
add csi and product generic labels on node and controller

### DIFF
--- a/pkg/internal/ibmblockcsi/ibmblockcsi.go
+++ b/pkg/internal/ibmblockcsi/ibmblockcsi.go
@@ -49,6 +49,8 @@ func (c *IBMBlockCSI) GetLabels() labels.Set {
 		"app.kubernetes.io/instance":   c.Name,
 		"app.kubernetes.io/version":    csiversion.Version,
 		"app.kubernetes.io/managed-by": config.Name,
+		"csi":                          "ibm",
+		"product":                      config.ProductName,
 	}
 
 	if c.Labels != nil {


### PR DESCRIPTION
node and controller pods (and statefulset\daemonset spec) should have the labels:
   product: ibm-block-csi-driver
   csi: ibm


also to allow quick search for kubectl get pod -l csi

CSI-622