### PR TITLE
Fix//CSI-535 multipath -f stuck

### DIFF
--- a/pkg/controller/config/syncer/node_agent.go
+++ b/pkg/controller/config/syncer/node_agent.go
@@ -92,6 +92,8 @@ func (s *nodeAgentSyncer) ensurePodSpec() corev1.PodSpec {
 	return corev1.PodSpec{
 		Containers:  s.ensureContainersSpec(),
 		Volumes:     s.ensureVolumes(),
+		HostNetwork: true,
+		DNSPolicy:   "ClusterFirstWithHostNet", // To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'
 	}
 }
 

--- a/pkg/controller/config/syncer/node_agent.go
+++ b/pkg/controller/config/syncer/node_agent.go
@@ -92,8 +92,6 @@ func (s *nodeAgentSyncer) ensurePodSpec() corev1.PodSpec {
 	return corev1.PodSpec{
 		Containers:  s.ensureContainersSpec(),
 		Volumes:     s.ensureVolumes(),
-		HostNetwork: true,
-		DNSPolicy:   "ClusterFirstWithHostNet", // To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'
 	}
 }
 

--- a/pkg/controller/ibmblockcsi/syncer/csi_node.go
+++ b/pkg/controller/ibmblockcsi/syncer/csi_node.go
@@ -93,8 +93,6 @@ func (s *csiNodeSyncer) ensurePodSpec() corev1.PodSpec {
 	return corev1.PodSpec{
 		Containers:         s.ensureContainersSpec(),
 		Volumes:            s.ensureVolumes(),
-		HostNetwork:        true,
-		DNSPolicy:          "ClusterFirstWithHostNet", // To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'
 		ServiceAccountName: "default",
 		Affinity: &corev1.Affinity{
 			NodeAffinity: ensureNodeAffinity(),

--- a/pkg/controller/ibmblockcsi/syncer/csi_node.go
+++ b/pkg/controller/ibmblockcsi/syncer/csi_node.go
@@ -93,6 +93,7 @@ func (s *csiNodeSyncer) ensurePodSpec() corev1.PodSpec {
 	return corev1.PodSpec{
 		Containers:         s.ensureContainersSpec(),
 		Volumes:            s.ensureVolumes(),
+		HostIPC:            true,
 		ServiceAccountName: "default",
 		Affinity: &corev1.Affinity{
 			NodeAffinity: ensureNodeAffinity(),


### PR DESCRIPTION
Per Xiao Yan Yang finding
adding hostIPC:true into the csi node spec can fix the hanging _multipath -f <device>_.

HostIPC - Controls whether the pod containers can share the host IPC namespace. And by default the k8s pod (security context) does NOT allow to share host IPC inside the pod.

So the multipath -f hanging because of it waiting to delete a multipath related semaphor on the host, so by set HostICP=false it solve this hanging issue.
