### PR TITLE
Change olm operator image URL from dockerhub to redhat registry

### DIFF
--- a/deploy/crds/csi.ibm.com_v1_ibmblockcsi_cr.yaml
+++ b/deploy/crds/csi.ibm.com_v1_ibmblockcsi_cr.yaml
@@ -40,7 +40,6 @@ spec:
                   values:
                     - amd64
 
-# use this tolerations if you want to deploy node pod on masters.
 #    tolerations:
 #    - effect: NoSchedule
 #      key: node-role.kubernetes.io/master
@@ -64,6 +63,5 @@ spec:
     tag: "v1.1.0"
     imagePullPolicy: IfNotPresent
 
-# specify your own image pull secrets here.
 #  imagePullSecrets:
 #  - "secretName"

--- a/deploy/olm-catalog/ibm-block-csi-operator/1.0.0/ibm-block-csi-operator.v1.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-block-csi-operator/1.0.0/ibm-block-csi-operator.v1.0.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     capabilities: "Seamless Upgrades"
     categories: "Storage,Cloud Provider"
     certified: "true"
-    containerImage: ibmcom/ibm-block-csi-operator:1.0.0
+    containerImage: registry.connect.redhat.com/ibm/ibm-block-csi-operator:1.0.0
     createdAt: "2019-11-05T16:45:00Z"
     description: "Run IBM block storage CSI driver on OpenShift."
     repository: https://github.com/IBM/ibm-block-csi-operator
@@ -548,7 +548,7 @@ spec:
                     capabilities:
                       drop:
                       - ALL
-                  image: ibmcom/ibm-block-csi-operator:1.0.0
+                  image: registry.connect.redhat.com/ibm/ibm-block-csi-operator:1.0.0
                   imagePullPolicy: IfNotPresent
                   command:
                   - ibm-block-csi-operator


### PR DESCRIPTION
For openshift users we need to set the operator image URL (OLM file) to be from redhat registry. 
From ibmcom/ibm-block-csi-operator:1.0.0  -> registry.connect.redhat.com/ibm/ibm-block-csi-operator:1.0.0

NOTE: we keep the operator also in dockerhub for regular k8s users in the operator.yaml file.
