### PR TITLE
upgrade driver during operator upgrade

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -42,8 +42,8 @@ const (
 	ENVKubeVersion    = "KUBE_VERSION"
 	ENVPlatform       = "PLATFORM"
 
-	Controller             = "csi-controller"
-	Node                   = "csi-node"
+	ControllerImage        = "csi-controller"
+	NodeImage              = "csi-node"
 	CSINodeDriverRegistrar = "csi-node-driver-registrar"
 	CSIProvisioner         = "csi-provisioner"
 	CSIAttacher            = "csi-attacher"

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -32,8 +32,8 @@ const (
 	NodeRepository       = "ibmcom/ibm-block-csi-driver-node"
 	NodeAgentRepository  = "ibmcom/ibm-node-agent"
 
-	OpenShiftControllerRepository = "ibmcom/ibm-block-csi-controller-driver"
-	OpenShiftNodeRepository       = "ibmcom/ibm-block-csi-node-driver"
+	OpenShiftControllerRepository = "ibmcom/ibm-block-csi-driver-controller"
+	OpenShiftNodeRepository       = "ibmcom/ibm-block-csi-driver-node"
 	OpenShiftNodeAgentRepository  = "ibmcom/ibm-node-agent"
 
 	ENVIscsiAgentPort = "ISCSI_AGENT_PORT"

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -18,6 +18,8 @@ package config
 
 // Add a field here if it never changes, if it changes over time, put it to settings.go
 const (
+	OpenShift   = "OpenShift"
+	Kubernetes  = "Kubernetes"
 	APIGroup    = "csi.ibm.com"
 	APIVersion  = "v1"
 	Name        = "ibm-block-csi-operator"
@@ -30,11 +32,18 @@ const (
 	NodeRepository       = "ibmcom/ibm-block-csi-node-driver"
 	NodeAgentRepository  = "ibmcom/ibm-node-agent"
 
+	OpenShiftControllerRepository = "ibmcom/ibm-block-csi-controller-driver"
+	OpenShiftNodeRepository       = "ibmcom/ibm-block-csi-node-driver"
+	OpenShiftNodeAgentRepository  = "ibmcom/ibm-node-agent"
+
 	ENVIscsiAgentPort = "ISCSI_AGENT_PORT"
 	ENVEndpoint       = "ENDPOINT"
 	ENVNodeName       = "NODE_NAME"
 	ENVKubeVersion    = "KUBE_VERSION"
+	ENVPlatform       = "PLATFORM"
 
+	Controller             = "csi-controller"
+	Node                   = "csi-node"
 	CSINodeDriverRegistrar = "csi-node-driver-registrar"
 	CSIProvisioner         = "csi-provisioner"
 	CSIAttacher            = "csi-attacher"

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -28,8 +28,8 @@ const (
 	DeployPath  = "/deploy"
 	Masterlabel = "node-role.kubernetes.io/master"
 
-	ControllerRepository = "ibmcom/ibm-block-csi-controller-driver"
-	NodeRepository       = "ibmcom/ibm-block-csi-node-driver"
+	ControllerRepository = "ibmcom/ibm-block-csi-driver-controller"
+	NodeRepository       = "ibmcom/ibm-block-csi-driver-node"
 	NodeAgentRepository  = "ibmcom/ibm-node-agent"
 
 	OpenShiftControllerRepository = "ibmcom/ibm-block-csi-controller-driver"

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -16,11 +16,18 @@
 
 package config
 
+import "k8s.io/apimachinery/pkg/util/sets"
+
 const (
-	NodeDriverRegistrarImage    = "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
-	CSIProvisionerImage         = "quay.io/k8scsi/csi-provisioner:v1.3.0"
-	CSIAttacherImage            = "quay.io/k8scsi/csi-attacher:v1.2.1"
-	CSILivenessProbeImage       = "quay.io/k8scsi/livenessprobe:v1.1.0"
+	NodeDriverRegistrarImage = "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+	CSIProvisionerImage      = "quay.io/k8scsi/csi-provisioner:v1.4.0"
+	CSIAttacherImage         = "quay.io/k8scsi/csi-attacher:v1.2.1"
+	CSILivenessProbeImage    = "quay.io/k8scsi/livenessprobe:v1.1.0"
+
+	OpenShiftNodeDriverRegistrarImage = "registry.redhat.io/openshift4/ose-csi-driver-registrar:v4.3"
+	OpenShiftCSIProvisionerImage      = "registry.redhat.io/openshift4/ose-csi-external-provisioner-rhel7:v4.3"
+	OpenShiftCSIAttacherImage         = "registry.redhat.io/openshift4/ose-csi-external-attacher:v4.3"
+	OpenShiftCSILivenessProbeImage    = "registry.redhat.io/openshift4/ose-csi-livenessprobe:v4.3"
 
 	ControllerTag = "1.1.0"
 	NodeTag       = "1.1.0"
@@ -32,3 +39,86 @@ const (
 
 	NodeAgentPort = "10086"
 )
+
+var ReplaceControllerVersions = sets.String{
+	ControllerRepository + ":" + "1.0.0": sets.Empty{},
+}
+
+var ReplaceNodeVersions = sets.String{
+	NodeRepository + ":" + "1.0.0": sets.Empty{},
+}
+
+var ReplaceCSIProvisionerVersions = sets.String{
+	"quay.io/k8scsi/csi-provisioner:v1.3.0": sets.Empty{},
+}
+
+var ReplaceCSIAttacherVersions = sets.String{}
+
+var ReplaceNodeDriverRegistrarVersions = sets.String{}
+
+var ReplaceLivenessProbeVersions = sets.String{}
+
+var ReplaceOpenShiftControllerVersions = sets.String{
+	OpenShiftControllerRepository + ":" + "1.0.0": sets.Empty{},
+}
+
+var ReplaceOpenShiftNodeVersions = sets.String{
+	OpenShiftNodeRepository + ":" + "1.0.0": sets.Empty{},
+}
+
+var ReplaceOpenShiftCSIProvisionerVersions = sets.String{
+	"quay.io/k8scsi/csi-provisioner:v1.3.0": sets.Empty{},
+}
+
+var ReplaceOpenShiftCSIAttacherVersions = sets.String{
+	"quay.io/k8scsi/csi-attacher:v1.2.1": sets.Empty{},
+}
+
+var ReplaceOpenShiftNodeDriverRegistrarVersions = sets.String{
+	"quay.io/k8scsi/csi-node-driver-registrar:v1.2.0": sets.Empty{},
+}
+
+var ReplaceOpenShiftLivenessProbeVersions = sets.String{
+	"quay.io/k8scsi/livenessprobe:v1.1.0": sets.Empty{},
+}
+
+func GetReplaceVersions(platform, image string) sets.String {
+	switch platform {
+	case OpenShift:
+		switch image {
+		case Controller:
+			return ReplaceOpenShiftControllerVersions
+		case Node:
+			return ReplaceOpenShiftNodeVersions
+		case CSIProvisioner:
+			return ReplaceOpenShiftCSIProvisionerVersions
+		case CSIAttacher:
+			return ReplaceOpenShiftCSIAttacherVersions
+		case CSINodeDriverRegistrar:
+			return ReplaceOpenShiftNodeDriverRegistrarVersions
+		case LivenessProbe:
+			return ReplaceOpenShiftLivenessProbeVersions
+		default:
+			return sets.String{}
+		}
+	case Kubernetes:
+		switch image {
+		case Controller:
+			return ReplaceControllerVersions
+		case Node:
+			return ReplaceNodeVersions
+		case CSIProvisioner:
+			return ReplaceCSIProvisionerVersions
+		case CSIAttacher:
+			return ReplaceCSIAttacherVersions
+		case CSINodeDriverRegistrar:
+			return ReplaceNodeDriverRegistrarVersions
+		case LivenessProbe:
+			return ReplaceLivenessProbeVersions
+		default:
+			return sets.String{}
+		}
+	default:
+		return sets.String{}
+	}
+}

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -86,9 +86,9 @@ func GetReplaceVersions(platform, image string) sets.String {
 	switch platform {
 	case OpenShift:
 		switch image {
-		case Controller:
+		case ControllerImage:
 			return ReplaceOpenShiftControllerVersions
-		case Node:
+		case NodeImage:
 			return ReplaceOpenShiftNodeVersions
 		case CSIProvisioner:
 			return ReplaceOpenShiftCSIProvisionerVersions
@@ -103,9 +103,9 @@ func GetReplaceVersions(platform, image string) sets.String {
 		}
 	case Kubernetes:
 		switch image {
-		case Controller:
+		case ControllerImage:
 			return ReplaceControllerVersions
-		case Node:
+		case NodeImage:
 			return ReplaceNodeVersions
 		case CSIProvisioner:
 			return ReplaceCSIProvisionerVersions

--- a/pkg/controller/ibmblockcsi/ibmblockcsi_controller.go
+++ b/pkg/controller/ibmblockcsi/ibmblockcsi_controller.go
@@ -70,7 +70,11 @@ func Add(mgr manager.Manager) error {
 func getServerPlatformAndVersion() (string, string, error) {
 	kubeVersion, found := os.LookupEnv(oconfig.ENVKubeVersion)
 	if found {
-		return oconfig.Kubernetes, os.Getenv(oconfig.ENVPlatform), nil
+		platform := os.Getenv(oconfig.ENVPlatform)
+		if platform == "" {
+			platform = oconfig.Kubernetes
+		}
+		return platform, kubeVersion, nil
 	}
 
 	platform := oconfig.Kubernetes

--- a/pkg/controller/ibmblockcsi/ibmblockcsi_controller.go
+++ b/pkg/controller/ibmblockcsi/ibmblockcsi_controller.go
@@ -65,6 +65,8 @@ func Add(mgr manager.Manager) error {
 	return add(mgr, newReconciler(mgr))
 }
 
+// getServerPlatformAndVersion return the platfrom and version of the server.
+// Default platform is Kubernetes, if we can not get the details from server.
 func getServerPlatformAndVersion() (string, string, error) {
 	kubeVersion, found := os.LookupEnv(oconfig.ENVKubeVersion)
 	if found {

--- a/pkg/controller/ibmblockcsi/syncer/csi_controller.go
+++ b/pkg/controller/ibmblockcsi/syncer/csi_controller.go
@@ -296,15 +296,15 @@ func (s *csiControllerSyncer) getLivenessProbeImage() string {
 }
 
 func (s *csiControllerSyncer) getCSIAttacherPullPolicy() corev1.PullPolicy {
-	return s.driver.getSidecarPullPolicyByName(config.CSIAttacher)
+	return s.driver.GetSidecarPullPolicyByName(config.CSIAttacher)
 }
 
 func (s *csiControllerSyncer) getCSIProvisionerPullPolicy() corev1.PullPolicy {
-	return s.driver.getSidecarPullPolicyByName(config.CSIProvisioner)
+	return s.driver.GetSidecarPullPolicyByName(config.CSIProvisioner)
 }
 
 func (s *csiControllerSyncer) getLivenessProbePullPolicy() corev1.PullPolicy {
-	return s.driver.getSidecarPullPolicyByName(config.LivenessProbe)
+	return s.driver.GetSidecarPullPolicyByName(config.LivenessProbe)
 }
 
 func ensurePorts(ports ...corev1.ContainerPort) []corev1.ContainerPort {

--- a/pkg/controller/ibmblockcsi/syncer/csi_controller.go
+++ b/pkg/controller/ibmblockcsi/syncer/csi_controller.go
@@ -296,27 +296,15 @@ func (s *csiControllerSyncer) getLivenessProbeImage() string {
 }
 
 func (s *csiControllerSyncer) getCSIAttacherPullPolicy() corev1.PullPolicy {
-	sidecar := s.dirver.getSidecarByName(config.CSIAttacher)
-	if sidecar != nil && sidecar.ImagePullPolicy != "" {
-		return sidecar.ImagePullPolicy
-	}
-	return corev1.PullIfNotPresent
+	return s.driver.getSidecarPullPolicyByName(config.CSIAttacher)
 }
 
 func (s *csiControllerSyncer) getCSIProvisionerPullPolicy() corev1.PullPolicy {
-	sidecar := s.dirver.getSidecarByName(config.CSIProvisioner)
-	if sidecar != nil && sidecar.ImagePullPolicy != "" {
-		return sidecar.ImagePullPolicy
-	}
-	return corev1.PullIfNotPresent
+	return s.driver.getSidecarPullPolicyByName(config.CSIProvisioner)
 }
 
 func (s *csiControllerSyncer) getLivenessProbePullPolicy() corev1.PullPolicy {
-	sidecar := s.dirver.getSidecarByName(config.LivenessProbe)
-	if sidecar != nil && sidecar.ImagePullPolicy != "" {
-		return sidecar.ImagePullPolicy
-	}
-	return corev1.PullIfNotPresent
+	return s.driver.getSidecarPullPolicyByName(config.LivenessProbe)
 }
 
 func ensurePorts(ports ...corev1.ContainerPort) []corev1.ContainerPort {

--- a/pkg/controller/ibmblockcsi/syncer/csi_node.go
+++ b/pkg/controller/ibmblockcsi/syncer/csi_node.go
@@ -319,11 +319,11 @@ func (s *csiNodeSyncer) getLivenessProbeImage() string {
 }
 
 func (s *csiNodeSyncer) getCSINodeDriverRegistrarPullPolicy() corev1.PullPolicy {
-	return s.driver.getSidecarPullPolicyByName(config.CSINodeDriverRegistrar)
+	return s.driver.GetSidecarPullPolicyByName(config.CSINodeDriverRegistrar)
 }
 
 func (s *csiNodeSyncer) getLivenessProbePullPolicy() corev1.PullPolicy {
-	return s.driver.getSidecarPullPolicyByName(config.LivenessProbe)
+	return s.driver.GetSidecarPullPolicyByName(config.LivenessProbe)
 }
 
 func ensureHostPathVolumeSource(path, pathType string) corev1.VolumeSource {

--- a/pkg/controller/ibmblockcsi/syncer/csi_node.go
+++ b/pkg/controller/ibmblockcsi/syncer/csi_node.go
@@ -17,8 +17,6 @@
 package syncer
 
 import (
-	"fmt"
-
 	"github.com/imdario/mergo"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -27,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	csiv1 "github.com/IBM/ibm-block-csi-operator/pkg/apis/csi/v1"
 	"github.com/IBM/ibm-block-csi-operator/pkg/config"
 	"github.com/IBM/ibm-block-csi-operator/pkg/internal/ibmblockcsi"
 	"github.com/IBM/ibm-block-csi-operator/pkg/util/boolptr"
@@ -97,7 +94,7 @@ func (s *csiNodeSyncer) ensurePodSpec() corev1.PodSpec {
 		Containers:         s.ensureContainersSpec(),
 		Volumes:            s.ensureVolumes(),
 		HostIPC:            true,
-		HostNetwork: 		true,
+		HostNetwork:        true,
 		ServiceAccountName: config.GetNameForResource(config.CSINodeServiceAccount, s.driver.Name),
 		Affinity:           s.driver.Spec.Node.Affinity,
 		Tolerations:        s.driver.Spec.Node.Tolerations,
@@ -313,28 +310,16 @@ func (s *csiNodeSyncer) ensureVolumes() []corev1.Volume {
 	}
 }
 
-func (s *csiNodeSyncer) getSidecarByName(name string) *csiv1.CSISidecar {
-	return getSidecarByName(s.driver, name)
-}
-
 func (s *csiNodeSyncer) getCSINodeDriverRegistrarImage() string {
-	sidecar := s.getSidecarByName(config.CSINodeDriverRegistrar)
-	if sidecar != nil {
-		return fmt.Sprintf("%s:%s", sidecar.Repository, sidecar.Tag)
-	}
-	return config.NodeDriverRegistrarImage
+	return s.driver.GetSidecarImageByName(config.CSINodeDriverRegistrar)
 }
 
 func (s *csiNodeSyncer) getLivenessProbeImage() string {
-	sidecar := s.getSidecarByName(config.LivenessProbe)
-	if sidecar != nil {
-		return fmt.Sprintf("%s:%s", sidecar.Repository, sidecar.Tag)
-	}
-	return config.CSILivenessProbeImage
+	return s.driver.GetSidecarImageByName(config.LivenessProbe)
 }
 
 func (s *csiNodeSyncer) getCSINodeDriverRegistrarPullPolicy() corev1.PullPolicy {
-	sidecar := s.getSidecarByName(config.CSINodeDriverRegistrar)
+	sidecar := s.driver.getSidecarByName(config.CSINodeDriverRegistrar)
 	if sidecar != nil && sidecar.ImagePullPolicy != "" {
 		return sidecar.ImagePullPolicy
 	}
@@ -342,7 +327,7 @@ func (s *csiNodeSyncer) getCSINodeDriverRegistrarPullPolicy() corev1.PullPolicy 
 }
 
 func (s *csiNodeSyncer) getLivenessProbePullPolicy() corev1.PullPolicy {
-	sidecar := s.getSidecarByName(config.LivenessProbe)
+	sidecar := s.driver.getSidecarByName(config.LivenessProbe)
 	if sidecar != nil && sidecar.ImagePullPolicy != "" {
 		return sidecar.ImagePullPolicy
 	}

--- a/pkg/controller/ibmblockcsi/syncer/csi_node.go
+++ b/pkg/controller/ibmblockcsi/syncer/csi_node.go
@@ -319,19 +319,11 @@ func (s *csiNodeSyncer) getLivenessProbeImage() string {
 }
 
 func (s *csiNodeSyncer) getCSINodeDriverRegistrarPullPolicy() corev1.PullPolicy {
-	sidecar := s.driver.getSidecarByName(config.CSINodeDriverRegistrar)
-	if sidecar != nil && sidecar.ImagePullPolicy != "" {
-		return sidecar.ImagePullPolicy
-	}
-	return corev1.PullIfNotPresent
+	return s.driver.getSidecarPullPolicyByName(config.CSINodeDriverRegistrar)
 }
 
 func (s *csiNodeSyncer) getLivenessProbePullPolicy() corev1.PullPolicy {
-	sidecar := s.driver.getSidecarByName(config.LivenessProbe)
-	if sidecar != nil && sidecar.ImagePullPolicy != "" {
-		return sidecar.ImagePullPolicy
-	}
-	return corev1.PullIfNotPresent
+	return s.driver.getSidecarPullPolicyByName(config.LivenessProbe)
 }
 
 func ensureHostPathVolumeSource(path, pathType string) corev1.VolumeSource {

--- a/pkg/internal/ibmblockcsi/default_setter.go
+++ b/pkg/internal/ibmblockcsi/default_setter.go
@@ -35,7 +35,7 @@ func (c *IBMBlockCSI) SetDefaults(platform string) bool {
 
 	// if controller is empty
 	if c.Spec.Controller.Repository == "" {
-		regAndTag := strings.Split(c.GetDefaultImageByPlatformAndName(platform, config.Controller), ":")
+		regAndTag := strings.Split(c.GetDefaultImageByPlatformAndName(platform, config.ControllerImage), ":")
 		c.Spec.Controller.Repository = regAndTag[0]
 		c.Spec.Controller.Tag = regAndTag[1]
 
@@ -44,14 +44,14 @@ func (c *IBMBlockCSI) SetDefaults(platform string) bool {
 
 	// if node is empty
 	if c.Spec.Node.Repository == "" {
-		regAndTag := strings.Split(c.GetDefaultImageByPlatformAndName(platform, config.Node), ":")
+		regAndTag := strings.Split(c.GetDefaultImageByPlatformAndName(platform, config.NodeImage), ":")
 		c.Spec.Node.Repository = regAndTag[0]
 		c.Spec.Node.Tag = regAndTag[1]
 
 		changed = true
 	}
 
-	if sidecarChanged := c.clearSidecars(platform); sidecarChanged {
+	if sidecarChanged := c.clearSidecarPreviousVersion(platform); sidecarChanged {
 		changed = sidecarChanged
 	}
 	if sidecarChanged := c.setDefualtSidecars(platform); sidecarChanged {
@@ -69,14 +69,14 @@ func (c *IBMBlockCSI) clearPreviousVersion(platform string) bool {
 	changed := false
 
 	// if controller is a replace version
-	if config.GetReplaceVersions(platform, config.Controller).Has(c.GetCSIControllerImage()) {
+	if config.GetReplaceVersions(platform, config.ControllerImage).Has(c.GetCSIControllerImage()) {
 		c.Spec.Controller.Repository = ""
 		c.Spec.Controller.Tag = ""
 		changed = true
 	}
 
 	// if node is a replace version
-	if config.GetReplaceVersions(platform, config.Node).Has(c.GetCSINodeImage()) {
+	if config.GetReplaceVersions(platform, config.NodeImage).Has(c.GetCSINodeImage()) {
 		c.Spec.Node.Repository = ""
 		c.Spec.Node.Tag = ""
 		changed = true
@@ -85,7 +85,7 @@ func (c *IBMBlockCSI) clearPreviousVersion(platform string) bool {
 	return changed
 }
 
-func (c *IBMBlockCSI) clearSidecars(platform string) bool {
+func (c *IBMBlockCSI) clearSidecarPreviousVersion(platform string) bool {
 	changed := false
 	var updated []csiv1.CSISidecar
 

--- a/pkg/internal/ibmblockcsi/default_setter.go
+++ b/pkg/internal/ibmblockcsi/default_setter.go
@@ -35,7 +35,7 @@ func (c *IBMBlockCSI) SetDefaults(platform string) bool {
 
 	// if controller is empty
 	if c.Spec.Controller.Repository == "" {
-		regAndTag := strings.Split(c.GetDefaultImageByName(platform, config.Controller), ":")
+		regAndTag := strings.Split(c.GetDefaultImageByPlatformAndName(platform, config.Controller), ":")
 		c.Spec.Controller.Repository = regAndTag[0]
 		c.Spec.Controller.Tag = regAndTag[1]
 
@@ -44,18 +44,18 @@ func (c *IBMBlockCSI) SetDefaults(platform string) bool {
 
 	// if node is empty
 	if c.Spec.Node.Repository == "" {
-		regAndTag := strings.Split(c.GetDefaultImageByName(platform, config.Node), ":")
+		regAndTag := strings.Split(c.GetDefaultImageByPlatformAndName(platform, config.Node), ":")
 		c.Spec.Node.Repository = regAndTag[0]
 		c.Spec.Node.Tag = regAndTag[1]
 
 		changed = true
 	}
 
-	if ch := c.clearSidecars(platform); ch {
-		changed = ch
+	if sidecarChanged := c.clearSidecars(platform); sidecarChanged {
+		changed = sidecarChanged
 	}
-	if ch := c.setDefualtSidecars(platform); ch {
-		changed = ch
+	if sidecarChanged := c.setDefualtSidecars(platform); sidecarChanged {
+		changed = sidecarChanged
 	}
 
 	return changed
@@ -108,7 +108,7 @@ func (c *IBMBlockCSI) setDefualtSidecars(platform string) bool {
 	for _, name := range c.GetSidecarNames() {
 		sidecar := c.GetSidecarByName(name)
 		if sidecar == nil || sidecar.Repository == "" {
-			regAndTag := strings.Split(c.GetDefaultImageByName(platform, name), ":")
+			regAndTag := strings.Split(c.GetDefaultImageByPlatformAndName(platform, name), ":")
 			sidecar = &csiv1.CSISidecar{
 				Name:            name,
 				Repository:      regAndTag[0],

--- a/pkg/internal/ibmblockcsi/default_setter.go
+++ b/pkg/internal/ibmblockcsi/default_setter.go
@@ -58,7 +58,20 @@ func (c *IBMBlockCSI) SetDefaults(platform string) bool {
 		changed = sidecarChanged
 	}
 
+	c.setDefaultSliceFields()
+
 	return changed
+}
+func (c *IBMBlockCSI) setDefaultSliceFields() {
+	if c.Spec.ImagePullSecrets == nil {
+		c.Spec.ImagePullSecrets = []string{}
+	}
+	if c.Spec.Controller.Tolerations == nil {
+		c.Spec.Controller.Tolerations = []corev1.Toleration{}
+	}
+	if c.Spec.Node.Tolerations == nil {
+		c.Spec.Node.Tolerations = []corev1.Toleration{}
+	}
 }
 
 // clearPreviousVersion clears the previous version of controller and node

--- a/pkg/internal/ibmblockcsi/default_setter.go
+++ b/pkg/internal/ibmblockcsi/default_setter.go
@@ -17,32 +17,109 @@
 package ibmblockcsi
 
 import (
+	"strings"
+
+	csiv1 "github.com/IBM/ibm-block-csi-operator/pkg/apis/csi/v1"
 	"github.com/IBM/ibm-block-csi-operator/pkg/config"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // SetDefaults set defaults if omitted in spec, returns true means CR should be updated on cluster.
 // Replace it with kubernetes native default setter when it is available.
 // https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#defaulting
-func (c *IBMBlockCSI) SetDefaults() bool {
+func (c *IBMBlockCSI) SetDefaults(platform string) bool {
 	// repository is mandatory, tag is optional, but if repository is not set
 	// and tag is set, the tag will be overrided to the default one.
-	changed := false
+
+	changed := c.replacePreviousVersion(platform)
 
 	// if controller is empty
 	if c.Spec.Controller.Repository == "" {
-		c.Spec.Controller.Repository = config.ControllerRepository
-		c.Spec.Controller.Tag = config.ControllerTag
+		regAndTag := strings.Split(c.GetDefaultImageByName(platform, config.Controller), ":")
+		c.Spec.Controller.Repository = regAndTag[0]
+		c.Spec.Controller.Tag = regAndTag[1]
 
 		changed = true
 	}
 
 	// if node is empty
 	if c.Spec.Node.Repository == "" {
-		c.Spec.Node.Repository = config.NodeRepository
-		c.Spec.Node.Tag = config.NodeTag
+		regAndTag := strings.Split(c.GetDefaultImageByName(platform, config.Node), ":")
+		c.Spec.Node.Repository = regAndTag[0]
+		c.Spec.Node.Tag = regAndTag[1]
 
 		changed = true
 	}
 
+	if ch := c.replaceSidecars(platform); ch {
+		changed = ch
+	}
+	if ch := c.setDefualtSidecars(platform); ch {
+		changed = ch
+	}
+
+	return changed
+}
+
+// replacePreviousVersion replaces the previous version of controller and node
+// images to new version during upgrade.
+// For example: If current controller image is ibmcom/ibm-block-csi-controller-driver:1.0.0,
+// it will be cleared and updated to ibmcom/ibm-block-csi-controller-driver:1.1.0 in setDefault().
+func (c *IBMBlockCSI) replacePreviousVersion(platform string) bool {
+	changed := false
+
+	// if controller is a replace version
+	if config.GetReplaceVersions(platform, config.Controller).Has(c.GetCSIControllerImage()) {
+		c.Spec.Controller.Repository = ""
+		c.Spec.Controller.Tag = ""
+		changed = true
+	}
+
+	// if node is a replace version
+	if config.GetReplaceVersions(platform, config.Node).Has(c.GetCSINodeImage()) {
+		c.Spec.Node.Repository = ""
+		c.Spec.Node.Tag = ""
+		changed = true
+	}
+
+	return changed
+}
+
+func (c *IBMBlockCSI) replaceSidecars(platform string) bool {
+	changed := false
+	var updated []csiv1.CSISidecar
+
+	for _, sidecar := range c.Spec.Sidecars {
+		if config.GetReplaceVersions(platform, sidecar.Name).Has(c.GetSidecarImageByName(sidecar.Name)) {
+			sidecar.Repository = ""
+			sidecar.Tag = ""
+			changed = true
+		}
+		updated = append(updated, sidecar)
+	}
+	c.Spec.Sidecars = updated
+	return changed
+}
+
+func (c *IBMBlockCSI) setDefualtSidecars(platform string) bool {
+	changed := false
+	var sidecars []csiv1.CSISidecar
+
+	for _, name := range c.GetSidecarNames() {
+		sidecar := c.GetSidecarByName(name)
+		if sidecar != nil && sidecar.Repository != "" {
+			sidecars = append(sidecars, *sidecar)
+		} else {
+			regAndTag := strings.Split(c.GetDefaultImageByName(platform, name), ":")
+			sidecars = append(sidecars, csiv1.CSISidecar{
+				Name:            name,
+				Repository:      regAndTag[0],
+				Tag:             regAndTag[1],
+				ImagePullPolicy: corev1.PullIfNotPresent,
+			})
+			changed = true
+		}
+	}
+	c.Spec.Sidecars = sidecars
 	return changed
 }

--- a/pkg/internal/ibmblockcsi/default_setter_test.go
+++ b/pkg/internal/ibmblockcsi/default_setter_test.go
@@ -17,6 +17,8 @@
 package ibmblockcsi_test
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -27,16 +29,21 @@ import (
 
 var _ = Describe("DefaultSetter", func() {
 	var ibc *csiv1.IBMBlockCSI = &csiv1.IBMBlockCSI{}
-	var ibcWrapper = New(ibc, "1.13")
+	var ibcWrapper = New(ibc, "1.14")
 	var changed bool
 
-	Context("test SetDefaults", func() {
+	Describe("test Kubernetes SetDefaults", func() {
 
 		JustBeforeEach(func() {
-			changed = ibcWrapper.SetDefaults()
+			changed = ibcWrapper.SetDefaults(config.Kubernetes)
 		})
 
 		Context("nothing is set", func() {
+
+			BeforeEach(func() {
+				ibc = &csiv1.IBMBlockCSI{}
+				ibcWrapper.IBMBlockCSI = ibc
+			})
 
 			It("should set right defaults", func() {
 				Expect(changed).To(BeTrue())
@@ -44,6 +51,7 @@ var _ = Describe("DefaultSetter", func() {
 				Expect(ibc.Spec.Controller.Tag).To(Equal(config.ControllerTag))
 				Expect(ibc.Spec.Node.Repository).To(Equal(config.NodeRepository))
 				Expect(ibc.Spec.Node.Tag).To(Equal(config.NodeTag))
+				Expect(ibc.Spec.Sidecars).To(HaveLen(4))
 			})
 		})
 
@@ -134,7 +142,7 @@ var _ = Describe("DefaultSetter", func() {
 		Context("everything is set", func() {
 
 			BeforeEach(func() {
-				ibcWrapper.SetDefaults()
+				ibcWrapper.SetDefaults(config.Kubernetes)
 			})
 
 			It("should do nothing", func() {
@@ -143,6 +151,166 @@ var _ = Describe("DefaultSetter", func() {
 				Expect(ibc.Spec.Controller.Tag).To(Equal(config.ControllerTag))
 				Expect(ibc.Spec.Node.Repository).To(Equal(config.NodeRepository))
 				Expect(ibc.Spec.Node.Tag).NotTo(Equal("test"))
+				Expect(ibc.Spec.Sidecars).To(HaveLen(4))
+			})
+		})
+
+		Context("controller and node version is 1.0.0", func() {
+
+			BeforeEach(func() {
+				ibc = &csiv1.IBMBlockCSI{
+					Spec: csiv1.IBMBlockCSISpec{
+						Controller: csiv1.IBMBlockCSIControllerSpec{
+							Repository: config.ControllerRepository,
+							Tag:        "1.0.0",
+						},
+						Node: csiv1.IBMBlockCSINodeSpec{
+							Repository: config.NodeRepository,
+							Tag:        "1.0.0",
+						},
+					}}
+				ibcWrapper.IBMBlockCSI = ibc
+			})
+
+			It("should be updated to new version", func() {
+				Expect(changed).To(BeTrue())
+				Expect(ibc.Spec.Controller.Repository).To(Equal(config.ControllerRepository))
+				Expect(ibc.Spec.Controller.Tag).To(Equal(config.ControllerTag))
+				Expect(ibc.Spec.Node.Repository).To(Equal(config.NodeRepository))
+				Expect(ibc.Spec.Node.Tag).To(Equal(config.NodeTag))
+			})
+		})
+
+		Context("csi provisioner version is v1.3.0", func() {
+
+			BeforeEach(func() {
+				ibc = &csiv1.IBMBlockCSI{
+					Spec: csiv1.IBMBlockCSISpec{
+						Sidecars: []csiv1.CSISidecar{
+							{
+								Name:       config.CSIProvisioner,
+								Repository: "quay.io/k8scsi/csi-provisioner",
+								Tag:        "v1.3.0",
+							},
+						},
+					}}
+				ibcWrapper.IBMBlockCSI = ibc
+			})
+
+			It("should be updated to new version", func() {
+				Expect(changed).To(BeTrue())
+				Expect(ibc.Spec.Sidecars).To(HaveLen(4))
+
+				for _, sidecar := range ibc.Spec.Sidecars {
+					if sidecar.Name == config.CSIProvisioner {
+						tag := strings.Split(config.CSIProvisionerImage, ":")[1]
+						Expect(sidecar.Tag).To(Equal(tag))
+					}
+				}
+			})
+		})
+	})
+
+	Describe("test OpenShift SetDefaults", func() {
+
+		JustBeforeEach(func() {
+			changed = ibcWrapper.SetDefaults(config.OpenShift)
+		})
+
+		Context("nothing is set", func() {
+
+			BeforeEach(func() {
+				ibc = &csiv1.IBMBlockCSI{}
+				ibcWrapper.IBMBlockCSI = ibc
+			})
+
+			It("should set right defaults", func() {
+				Expect(changed).To(BeTrue())
+				Expect(ibc.Spec.Controller.Repository).To(Equal(config.OpenShiftControllerRepository))
+				Expect(ibc.Spec.Controller.Tag).To(Equal(config.ControllerTag))
+				Expect(ibc.Spec.Node.Repository).To(Equal(config.OpenShiftNodeRepository))
+				Expect(ibc.Spec.Node.Tag).To(Equal(config.NodeTag))
+				Expect(ibc.Spec.Sidecars).To(HaveLen(4))
+			})
+		})
+
+		Context("everything is set", func() {
+
+			BeforeEach(func() {
+				ibcWrapper.SetDefaults(config.OpenShift)
+			})
+
+			It("should do nothing", func() {
+				Expect(changed).To(BeFalse())
+			})
+		})
+
+		Context("controller and node version is 1.0.0", func() {
+
+			BeforeEach(func() {
+				ibc = &csiv1.IBMBlockCSI{
+					Spec: csiv1.IBMBlockCSISpec{
+						Controller: csiv1.IBMBlockCSIControllerSpec{
+							Repository: config.ControllerRepository,
+							Tag:        "1.0.0",
+						},
+						Node: csiv1.IBMBlockCSINodeSpec{
+							Repository: config.NodeRepository,
+							Tag:        "1.0.0",
+						},
+					}}
+				ibcWrapper.IBMBlockCSI = ibc
+			})
+
+			It("should be updated to new version", func() {
+				Expect(changed).To(BeTrue())
+				Expect(ibc.Spec.Controller.Repository).To(Equal(config.OpenShiftControllerRepository))
+				Expect(ibc.Spec.Controller.Tag).To(Equal(config.ControllerTag))
+				Expect(ibc.Spec.Node.Repository).To(Equal(config.OpenShiftNodeRepository))
+				Expect(ibc.Spec.Node.Tag).To(Equal(config.NodeTag))
+			})
+		})
+
+		Context("csi provisioner version is v1.3.0", func() {
+
+			BeforeEach(func() {
+				ibc = &csiv1.IBMBlockCSI{
+					Spec: csiv1.IBMBlockCSISpec{
+						Sidecars: []csiv1.CSISidecar{
+							{
+								Name:       config.CSIProvisioner,
+								Repository: "quay.io/k8scsi/csi-provisioner",
+								Tag:        "v1.3.0",
+							},
+							{
+								Name:       config.CSIAttacher,
+								Repository: "quay.io/k8scsi/csi-attacher",
+								Tag:        "v1.2.1",
+							},
+							{
+								Name:       config.CSINodeDriverRegistrar,
+								Repository: "quay.io/k8scsi/csi-node-driver-registrar",
+								Tag:        "v1.2.0",
+							},
+							{
+								Name:       config.LivenessProbe,
+								Repository: "quay.io/k8scsi/livenessprobe",
+								Tag:        "v1.1.0",
+							},
+						},
+					}}
+				ibcWrapper.IBMBlockCSI = ibc
+			})
+
+			It("should be updated to new version", func() {
+				Expect(changed).To(BeTrue())
+				Expect(ibc.Spec.Sidecars).To(HaveLen(4))
+
+				for _, sidecar := range ibc.Spec.Sidecars {
+					repAndTag := strings.Split(ibcWrapper.GetOpenShiftDefaultImageByName(sidecar.Name), ":")
+					Expect(sidecar.Repository).To(Equal(repAndTag[0]))
+					Expect(sidecar.Tag).To(Equal(repAndTag[1]))
+				}
 			})
 		})
 

--- a/pkg/internal/ibmblockcsi/default_setter_test.go
+++ b/pkg/internal/ibmblockcsi/default_setter_test.go
@@ -52,6 +52,12 @@ var _ = Describe("DefaultSetter", func() {
 				Expect(ibc.Spec.Node.Repository).To(Equal(config.NodeRepository))
 				Expect(ibc.Spec.Node.Tag).To(Equal(config.NodeTag))
 				Expect(ibc.Spec.Sidecars).To(HaveLen(4))
+				Expect(ibc.Spec.ImagePullSecrets).NotTo(BeNil())
+				Expect(ibc.Spec.ImagePullSecrets).To(HaveLen(0))
+				Expect(ibc.Spec.Controller.Tolerations).NotTo(BeNil())
+				Expect(ibc.Spec.Controller.Tolerations).To(HaveLen(0))
+				Expect(ibc.Spec.Node.Tolerations).NotTo(BeNil())
+				Expect(ibc.Spec.Node.Tolerations).To(HaveLen(0))
 			})
 		})
 

--- a/pkg/internal/ibmblockcsi/ibmblockcsi.go
+++ b/pkg/internal/ibmblockcsi/ibmblockcsi.go
@@ -170,9 +170,9 @@ func (c *IBMBlockCSI) GetDefaultImageByPlatformAndName(platform, name string) st
 
 func (c *IBMBlockCSI) GetKubernetesDefaultImageByName(name string) string {
 	switch name {
-	case config.Controller:
+	case config.ControllerImage:
 		return config.ControllerRepository + ":" + config.ControllerTag
-	case config.Node:
+	case config.NodeImage:
 		return config.NodeRepository + ":" + config.NodeTag
 	case config.CSIProvisioner:
 		return config.CSIProvisionerImage
@@ -189,9 +189,9 @@ func (c *IBMBlockCSI) GetKubernetesDefaultImageByName(name string) string {
 
 func (c *IBMBlockCSI) GetOpenShiftDefaultImageByName(name string) string {
 	switch name {
-	case config.Controller:
+	case config.ControllerImage:
 		return config.OpenShiftControllerRepository + ":" + config.ControllerTag
-	case config.Node:
+	case config.NodeImage:
 		return config.OpenShiftNodeRepository + ":" + config.NodeTag
 	case config.CSIProvisioner:
 		return config.OpenShiftCSIProvisionerImage

--- a/pkg/internal/ibmblockcsi/ibmblockcsi.go
+++ b/pkg/internal/ibmblockcsi/ibmblockcsi.go
@@ -17,6 +17,8 @@
 package ibmblockcsi
 
 import (
+	"fmt"
+
 	csiv1 "github.com/IBM/ibm-block-csi-operator/pkg/apis/csi/v1"
 	"github.com/IBM/ibm-block-csi-operator/pkg/config"
 	csiversion "github.com/IBM/ibm-block-csi-operator/version"
@@ -118,4 +120,79 @@ func (c *IBMBlockCSI) GetCSINodeImage() string {
 		return c.Spec.Node.Repository
 	}
 	return c.Spec.Node.Repository + ":" + c.Spec.Node.Tag
+}
+
+func (c *IBMBlockCSI) GetSidecarNames() []string {
+	return []string{
+		config.CSIAttacher,
+		config.CSIProvisioner,
+		config.CSINodeDriverRegistrar,
+		config.LivenessProbe,
+	}
+}
+
+func (c *IBMBlockCSI) GetSidecarByName(name string) *csiv1.CSISidecar {
+	for _, sidecar := range c.Spec.Sidecars {
+		if sidecar.Name == name {
+			return &sidecar
+		}
+	}
+	return nil
+}
+
+func (c *IBMBlockCSI) GetSidecarImageByName(name string) string {
+	sidecar := c.GetSidecarByName(name)
+	if sidecar != nil {
+		return fmt.Sprintf("%s:%s", sidecar.Repository, sidecar.Tag)
+	}
+	return ""
+}
+
+func (c *IBMBlockCSI) GetDefaultImageByName(platform, name string) string {
+	switch platform {
+	case config.OpenShift:
+		return c.GetOpenShiftDefaultImageByName(name)
+	case config.Kubernetes:
+		return c.GetKubernetesDefaultImageByName(name)
+	default:
+		return ""
+	}
+}
+
+func (c *IBMBlockCSI) GetKubernetesDefaultImageByName(name string) string {
+	switch name {
+	case config.Controller:
+		return config.ControllerRepository + ":" + config.ControllerTag
+	case config.Node:
+		return config.NodeRepository + ":" + config.NodeTag
+	case config.CSIProvisioner:
+		return config.CSIProvisionerImage
+	case config.CSIAttacher:
+		return config.CSIAttacherImage
+	case config.CSINodeDriverRegistrar:
+		return config.NodeDriverRegistrarImage
+	case config.LivenessProbe:
+		return config.CSILivenessProbeImage
+	default:
+		return ""
+	}
+}
+
+func (c *IBMBlockCSI) GetOpenShiftDefaultImageByName(name string) string {
+	switch name {
+	case config.Controller:
+		return config.OpenShiftControllerRepository + ":" + config.ControllerTag
+	case config.Node:
+		return config.OpenShiftNodeRepository + ":" + config.NodeTag
+	case config.CSIProvisioner:
+		return config.OpenShiftCSIProvisionerImage
+	case config.CSIAttacher:
+		return config.OpenShiftCSIAttacherImage
+	case config.CSINodeDriverRegistrar:
+		return config.OpenShiftNodeDriverRegistrarImage
+	case config.LivenessProbe:
+		return config.OpenShiftCSILivenessProbeImage
+	default:
+		return ""
+	}
 }

--- a/pkg/internal/ibmblockcsi/ibmblockcsi.go
+++ b/pkg/internal/ibmblockcsi/ibmblockcsi.go
@@ -157,7 +157,7 @@ func (c *IBMBlockCSI) GetSidecarImageByName(name string) string {
 	return ""
 }
 
-func (c *IBMBlockCSI) GetDefaultImageByName(platform, name string) string {
+func (c *IBMBlockCSI) GetDefaultImageByPlatformAndName(platform, name string) string {
 	switch platform {
 	case config.OpenShift:
 		return c.GetOpenShiftDefaultImageByName(name)

--- a/pkg/internal/ibmblockcsi/ibmblockcsi.go
+++ b/pkg/internal/ibmblockcsi/ibmblockcsi.go
@@ -22,6 +22,7 @@ import (
 	csiv1 "github.com/IBM/ibm-block-csi-operator/pkg/apis/csi/v1"
 	"github.com/IBM/ibm-block-csi-operator/pkg/config"
 	csiversion "github.com/IBM/ibm-block-csi-operator/version"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -138,6 +139,14 @@ func (c *IBMBlockCSI) GetSidecarByName(name string) *csiv1.CSISidecar {
 		}
 	}
 	return nil
+}
+
+func (c *IBMBlockCSI) getSidecarPullPolicyByName(name string) corev1.PullPolicy {
+	sidecar := c.GetSidecarByName(name)
+	if sidecar != nil && sidecar.ImagePullPolicy != "" {
+		return sidecar.ImagePullPolicy
+	}
+	return corev1.PullIfNotPresent
 }
 
 func (c *IBMBlockCSI) GetSidecarImageByName(name string) string {

--- a/pkg/internal/ibmblockcsi/ibmblockcsi.go
+++ b/pkg/internal/ibmblockcsi/ibmblockcsi.go
@@ -141,7 +141,7 @@ func (c *IBMBlockCSI) GetSidecarByName(name string) *csiv1.CSISidecar {
 	return nil
 }
 
-func (c *IBMBlockCSI) getSidecarPullPolicyByName(name string) corev1.PullPolicy {
+func (c *IBMBlockCSI) GetSidecarPullPolicyByName(name string) corev1.PullPolicy {
 	sidecar := c.GetSidecarByName(name)
 	if sidecar != nil && sidecar.ImagePullPolicy != "" {
 		return sidecar.ImagePullPolicy


### PR DESCRIPTION
Per the suggestion from RedHat, we should update the cr during upgrading operator so that the driver will be upgraded together.
This pr
1. Update the controller, node and sidecars images if the defualt values were used in previous version
2. Skip the update if they were modified, for example, a private registry is used.

Jira ticket: CSI-1284