### PR TITLE
Fix/change olm operator image to dockerhub

### DIFF
--- a/deploy/olm-catalog/ibm-block-csi-operator/1.1.0/ibm-block-csi-operator.v1.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-block-csi-operator/1.1.0/ibm-block-csi-operator.v1.1.0.clusterserviceversion.yaml
@@ -617,7 +617,7 @@ spec:
                     capabilities:
                       drop:
                       - ALL
-                  image: ibmcom/ibm-block-csi-operator:1.1.0
+                  image: registry.connect.redhat.com/ibm/ibm-block-csi-operator:1.1.0
                   imagePullPolicy: IfNotPresent
                   command:
                   - ibm-block-csi-operator

--- a/deploy/olm-catalog/ibm-block-csi-operator/1.1.0/ibm-block-csi-operator.v1.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-block-csi-operator/1.1.0/ibm-block-csi-operator.v1.1.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     capabilities: "Basic Install"
     categories: "Storage,Cloud Provider"
     certified: "true"
-    containerImage: registry.connect.redhat.com/ibm/ibm-block-csi-operator:1.1.0
+    containerImage: ibmcom/ibm-block-csi-operator:1.1.0
     createdAt: "2020-02-19T13:14:00Z"
     description: "Run IBM block storage CSI driver on OpenShift."
     repository: https://github.com/IBM/ibm-block-csi-operator

--- a/deploy/olm-catalog/ibm-block-csi-operator/1.1.0/ibm-block-csi-operator.v1.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-block-csi-operator/1.1.0/ibm-block-csi-operator.v1.1.0.clusterserviceversion.yaml
@@ -617,7 +617,7 @@ spec:
                     capabilities:
                       drop:
                       - ALL
-                  image: registry.connect.redhat.com/ibm/ibm-block-csi-operator:1.1.0
+                  image: ibmcom/ibm-block-csi-operator:1.1.0
                   imagePullPolicy: IfNotPresent
                   command:
                   - ibm-block-csi-operator


### PR DESCRIPTION
This is what we finally put in the Red Hat "Operator Config" metadata zip for 1.1.0.
We hoped we could change to DockerHub, but it didn't actually work.