### PR TITLE
Task/csi 1888 workaround for operator generate crds failure

### DIFF
--- a/build/Dockerfile.nodeagent
+++ b/build/Dockerfile.nodeagent
@@ -2,7 +2,7 @@ FROM golang:1.13.1
 
 WORKDIR /go/src/github.com/IBM/ibm-block-csi-operator/
 COPY . .
-RUN CGO_ENABLED=1 GOOS=linux go build -o ibm-node-agent -gcflags all=-trimpath=${GOPATH} -asmflags all=-trimpath=${GOPATH} cmd/node/main.go
+RUN CGO_ENABLED=1 GOOS=linux go build -mod vendor -o ibm-node-agent -gcflags all=-trimpath=${GOPATH} -asmflags all=-trimpath=${GOPATH} cmd/node/main.go
 
 
 FROM registry.access.redhat.com/ubi7/ubi:7.6-177

--- a/hack/update-crds.sh
+++ b/hack/update-crds.sh
@@ -23,6 +23,7 @@ if ! [ -x "$(command -v operator-sdk)" ]; then
   exit 1
 fi
 
-operator-sdk generate k8s
+# Disable generation due failure see CSI-1888
+#operator-sdk generate k8s
 
-operator-sdk generate openapi
+#operator-sdk generate openapi


### PR DESCRIPTION
CSI-1888
This is a work around for our CI operator build failure due to code generation (operator-sdk generate k8s / operator-sdk generate openapi) env problem.