### PR TITLE
CSI-2459 bump operator version to 1.5.0

### DIFF
--- a/build/Dockerfile.operator
+++ b/build/Dockerfile.operator
@@ -27,7 +27,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build \
 FROM registry.access.redhat.com/ubi7/ubi-minimal:7.9-224
 MAINTAINER IBM Storage
 
-ARG VERSION=1.4.0
+ARG VERSION=1.5.0
 ARG BUILD_NUMBER=0
 
 ###Required Labels

--- a/deploy/crds/csi.ibm.com_ibmblockcsis_crd.yaml
+++ b/deploy/crds/csi.ibm.com_ibmblockcsis_crd.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: ibmblockcsis
     app.kubernetes.io/managed-by: ibm-block-csi-operator
     product: ibm-block-csi-driver
-    release: v1.4.0
+    release: v1.5.0
     csi: ibm
 spec:
   group: csi.ibm.com

--- a/deploy/crds/csi.ibm.com_v1_ibmblockcsi_cr.yaml
+++ b/deploy/crds/csi.ibm.com_v1_ibmblockcsi_cr.yaml
@@ -7,13 +7,13 @@ metadata:
     app.kubernetes.io/name: ibm-block-csi
     app.kubernetes.io/instance: ibm-block-csi
     app.kubernetes.io/managed-by: ibm-block-csi-operator
-    release: v1.4.0
+    release: v1.5.0
 spec:
   # controller is a statefulSet with ibm-block-csi-controller container
   # and csi-provisioner, csi-attacher, csi-snapshotter and livenessprobe sidecars.
   controller:
     repository: ibmcom/ibm-block-csi-driver-controller
-    tag: "1.4.0"
+    tag: "1.5.0"
     imagePullPolicy: IfNotPresent
     affinity:
       nodeAffinity:
@@ -31,7 +31,7 @@ spec:
   # and csi-node-driver-registrar and livenessprobe sidecars.
   node:
     repository: ibmcom/ibm-block-csi-driver-node
-    tag: "1.4.0"
+    tag: "1.5.0"
     imagePullPolicy: IfNotPresent
     affinity:
       nodeAffinity:

--- a/deploy/installer/generated/ibm-block-csi-operator.yaml
+++ b/deploy/installer/generated/ibm-block-csi-operator.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: ibmblockcsis
     app.kubernetes.io/managed-by: ibm-block-csi-operator
     product: ibm-block-csi-driver
-    release: v1.4.0
+    release: v1.5.0
     csi: ibm
 spec:
   group: csi.ibm.com
@@ -1432,7 +1432,7 @@ spec:
       annotations:
         productName: "IBM Block CSI Driver"
         productID: "5027566ef6c54de49028be7df25119e1"
-        productVersion: "1.4.0"
+        productVersion: "1.5.0"
         productMetric: "FREE"
     spec:
       serviceAccountName: ibm-block-csi-operator
@@ -1470,7 +1470,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: ibmcom/ibm-block-csi-operator:1.4.0
+        image: ibmcom/ibm-block-csi-operator:1.5.0
         imagePullPolicy: IfNotPresent
         command:
         - ibm-block-csi-operator
@@ -1745,4 +1745,4 @@ metadata:
     app.kubernetes.io/name: ibm-block-csi-operator
     app.kubernetes.io/instance: ibm-block-csi-operator
     app.kubernetes.io/managed-by: ibm-block-csi-operator
-    release: v1.4.0
+    release: v1.5.0

--- a/deploy/olm-catalog/ibm-block-csi-operator/csi.ibm.com_ibmblockcsis_crd.yaml
+++ b/deploy/olm-catalog/ibm-block-csi-operator/csi.ibm.com_ibmblockcsis_crd.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: ibmblockcsis
     app.kubernetes.io/managed-by: ibm-block-csi-operator
     product: ibm-block-csi-driver
-    release: v1.4.0
+    release: v1.5.0
     csi: ibm
 spec:
   group: csi.ibm.com

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         productName: "IBM Block CSI Driver"
         productID: "5027566ef6c54de49028be7df25119e1"
-        productVersion: "1.4.0"
+        productVersion: "1.5.0"
         productMetric: "FREE"
     spec:
       serviceAccountName: ibm-block-csi-operator
@@ -63,7 +63,7 @@ spec:
           capabilities:
             drop:
             - ALL
-        image: ibmcom/ibm-block-csi-operator:1.4.0
+        image: ibmcom/ibm-block-csi-operator:1.5.0
         imagePullPolicy: IfNotPresent
         command:
         - ibm-block-csi-operator

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -9,4 +9,4 @@ metadata:
     app.kubernetes.io/name: ibm-block-csi-operator
     app.kubernetes.io/instance: ibm-block-csi-operator
     app.kubernetes.io/managed-by: ibm-block-csi-operator
-    release: v1.4.0
+    release: v1.5.0

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -24,8 +24,8 @@ const (
 	CSISnapshotterImage      	= "quay.io/k8scsi/csi-snapshotter:v2.1.0"
 	CSIResizerImage             = "k8s.gcr.io/sig-storage/csi-resizer:v1.0.0"
 
-	ControllerTag = "1.4.0"
-	NodeTag       = "1.4.0"
+	ControllerTag = "1.5.0"
+	NodeTag       = "1.5.0"
 	NodeAgentTag  = "1.0.0"
 
 	DefaultNamespace = "default"

--- a/version/version.go
+++ b/version/version.go
@@ -17,6 +17,6 @@
 package version
 
 var (
-	Version       = "1.4.0"
-	DriverVersion = "1.4.0"
+	Version       = "1.5.0"
+	DriverVersion = "1.5.0"
 )


### PR DESCRIPTION
similar PR in driver: https://github.com/IBM/ibm-block-csi-driver/pull/283