### PR TITLE
CSI-2438 enable non-x86 community installation

### DIFF
--- a/deploy/olm-catalog/ibm-block-csi-operator-community/1.5.0/ibm-block-csi-operator.v1.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-block-csi-operator-community/1.5.0/ibm-block-csi-operator.v1.5.0.clusterserviceversion.yaml
@@ -3,6 +3,10 @@ kind: ClusterServiceVersion
 metadata:
   name: ibm-block-csi-operator.v1.5.0
   namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/arch.ppc64le: supported
   annotations:
     capabilities: "Basic Install"
     categories: "Storage,Cloud Provider"


### PR DESCRIPTION
https://olm.operatorframework.io/docs/advanced-tasks/ship-operator-supporting-multiarch/