### PR TITLE
CSI-2844 update sidecars versions

### DIFF
--- a/deploy/crds/csi.ibm.com_v1_ibmblockcsi_cr.yaml
+++ b/deploy/crds/csi.ibm.com_v1_ibmblockcsi_cr.yaml
@@ -53,27 +53,27 @@ spec:
   sidecars:
   - name: csi-node-driver-registrar
     repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-    tag: "v2.0.1"
+    tag: "v2.1.0"
     imagePullPolicy: IfNotPresent
   - name: csi-provisioner
     repository: k8s.gcr.io/sig-storage/csi-provisioner
-    tag: "v2.0.4"
+    tag: "v2.1.0"
     imagePullPolicy: IfNotPresent
   - name: csi-attacher
     repository: k8s.gcr.io/sig-storage/csi-attacher
-    tag: "v3.0.2"
+    tag: "v3.1.0"
     imagePullPolicy: IfNotPresent
   - name: csi-snapshotter
     repository: k8s.gcr.io/sig-storage/csi-snapshotter
-    tag: "v3.0.2"
+    tag: "v4.0.0"
     imagePullPolicy: IfNotPresent
   - name: csi-resizer
     repository: k8s.gcr.io/sig-storage/csi-resizer
-    tag: "v1.0.1"
+    tag: "v1.1.0"
     imagePullPolicy: IfNotPresent
   - name: livenessprobe
     repository: k8s.gcr.io/sig-storage/livenessprobe
-    tag: "v2.1.0"
+    tag: "v2.2.0"
     imagePullPolicy: IfNotPresent
 
 #  imagePullSecrets:

--- a/deploy/olm-catalog/ibm-block-csi-operator-community/1.6.0/ibm-block-csi-operator.v1.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-block-csi-operator-community/1.6.0/ibm-block-csi-operator.v1.6.0.clusterserviceversion.yaml
@@ -81,37 +81,37 @@ metadata:
               {
                 "name": "csi-node-driver-registrar",
                 "repository": "k8s.gcr.io/sig-storage/csi-node-driver-registrar",
-                "tag": "v2.0.1",
+                "tag": "v2.1.0",
                 "imagePullPolicy": "IfNotPresent"
               },
               {
                 "name": "csi-provisioner",
                 "repository": "k8s.gcr.io/sig-storage/csi-provisioner",
-                "tag": "v2.0.4",
+                "tag": "v2.1.0",
                 "imagePullPolicy": "IfNotPresent"
               },
               {
                 "name": "csi-attacher",
                 "repository": "k8s.gcr.io/sig-storage/csi-attacher",
-                "tag": "v3.0.2",
+                "tag": "v3.1.0",
                 "imagePullPolicy": "IfNotPresent"
               },
               {
                 "name": "csi-snapshotter",
                 "repository": "k8s.gcr.io/sig-storage/csi-snapshotter",
-                "tag": "v3.0.2",
+                "tag": "v4.0.0",
                 "imagePullPolicy": "IfNotPresent"
               },
               {
                 "name": "csi-resizer",
                 "repository": "k8s.gcr.io/sig-storage/csi-resizer",
-                "tag": "v1.0.1",
+                "tag": "v1.1.0",
                 "imagePullPolicy": "IfNotPresent"
               },
               {
                 "name": "livenessprobe",
                 "repository": "k8s.gcr.io/sig-storage/livenessprobe",
-                "tag": "v2.1.0",
+                "tag": "v2.2.0",
                 "imagePullPolicy": "IfNotPresent"
               }
             ]

--- a/deploy/olm-catalog/ibm-block-csi-operator/1.6.0/manifests/ibm-block-csi-operator.v1.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-block-csi-operator/1.6.0/manifests/ibm-block-csi-operator.v1.6.0.clusterserviceversion.yaml
@@ -75,37 +75,37 @@ metadata:
               {
                 "name": "csi-node-driver-registrar",
                 "repository": "k8s.gcr.io/sig-storage/csi-node-driver-registrar",
-                "tag": "v2.0.1",
+                "tag": "v2.1.0",
                 "imagePullPolicy": "IfNotPresent"
               },
               {
                 "name": "csi-provisioner",
                 "repository": "k8s.gcr.io/sig-storage/csi-provisioner",
-                "tag": "v2.0.4",
+                "tag": "v2.1.0",
                 "imagePullPolicy": "IfNotPresent"
               },
               {
                 "name": "csi-attacher",
                 "repository": "k8s.gcr.io/sig-storage/csi-attacher",
-                "tag": "v3.0.2",
+                "tag": "v3.1.0",
                 "imagePullPolicy": "IfNotPresent"
               },
               {
                 "name": "csi-snapshotter",
                 "repository": "k8s.gcr.io/sig-storage/csi-snapshotter",
-                "tag": "v3.0.2",
+                "tag": "v4.0.0",
                 "imagePullPolicy": "IfNotPresent"
               },
               {
                 "name": "csi-resizer",
                 "repository": "k8s.gcr.io/sig-storage/csi-resizer",
-                "tag": "v1.0.1",
+                "tag": "v1.1.0",
                 "imagePullPolicy": "IfNotPresent"
               },
               {
                 "name": "livenessprobe",
                 "repository": "k8s.gcr.io/sig-storage/livenessprobe",
-                "tag": "v2.1.0",
+                "tag": "v2.2.0",
                 "imagePullPolicy": "IfNotPresent"
               }
             ]


### PR DESCRIPTION
Based on [this](https://github.com/IBM/ibm-block-csi-operator/commit/df934e9bca5c7a590e0c6f367e8f80c6b60c8881) commit
I took the latest version numbers from [here](https://kubernetes-csi.github.io/docs/sidecar-containers.html#versioning)