### PR TITLE
CSI-2602 increase controller liveness time

### DIFF
--- a/pkg/controller/ibmblockcsi/syncer/csi_controller.go
+++ b/pkg/controller/ibmblockcsi/syncer/csi_controller.go
@@ -125,7 +125,7 @@ func (s *csiControllerSyncer) ensureContainersSpec() []corev1.Container {
 	})
 	controllerPlugin.ImagePullPolicy = s.driver.Spec.Controller.ImagePullPolicy
 
-	controllerPlugin.LivenessProbe = ensureProbe(10, 100, 2, corev1.Handler{
+	controllerPlugin.LivenessProbe = ensureProbe(10, 100, 5, corev1.Handler{
 		HTTPGet: &corev1.HTTPGetAction{
 			Path:   "/healthz",
 			Port:   controllerContainerHealthPort,


### PR DESCRIPTION
increase csi controller time to respond before restart, from 1 minute to 2.5 minutes.
https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/