### PR TITLE
CSI-2691 printing the version in the logs

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/IBM/ibm-block-csi-operator/pkg/apis"
 	operatorConfig "github.com/IBM/ibm-block-csi-operator/pkg/config"
+	operatorVersion "github.com/IBM/ibm-block-csi-operator/version"
 	"github.com/IBM/ibm-block-csi-operator/pkg/controller"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
@@ -58,6 +59,7 @@ func printVersion() {
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
+	log.Info(fmt.Sprintf("Operator version: %v", operatorVersion.Version))
 }
 
 func main() {


### PR DESCRIPTION
This will look like:
`2021-04-07T15:10:38.256Z        INFO    cmd     Operator version: 1.6.0`

