### PR TITLE
Revert "CSI-2899 topology controller support"

### DIFF
--- a/pkg/controller/ibmblockcsi/syncer/csi_controller.go
+++ b/pkg/controller/ibmblockcsi/syncer/csi_controller.go
@@ -137,7 +137,7 @@ func (s *csiControllerSyncer) ensureContainersSpec() []corev1.Container {
 	provisioner := s.ensureContainer(provisionerContainerName,
 		s.getCSIProvisionerImage(),
 		// TODO: make timeout configurable
-		[]string{"--csi-address=$(ADDRESS)", "--v=5", "--timeout=30s", "--default-fstype=ext4", "--feature-gates=Topology=true"},
+		[]string{"--csi-address=$(ADDRESS)", "--v=5", "--timeout=30s", "--default-fstype=ext4"},
 	)
 	provisioner.ImagePullPolicy = s.getCSIProvisionerPullPolicy()
 


### PR DESCRIPTION
Reverts IBM/ibm-block-csi-operator#158
disable topology feature.