### PR TITLE
deprecation remove support before 4.6 ocp

### DIFF
--- a/deploy/olm-catalog/ibm-block-csi-operator/1.6.0/bundle-1.6.0.Dockerfile
+++ b/deploy/olm-catalog/ibm-block-csi-operator/1.6.0/bundle-1.6.0.Dockerfile
@@ -11,4 +11,3 @@ COPY manifests /manifests/
 COPY metadata /metadata/
 LABEL com.redhat.openshift.versions="v4.7,v4.8"
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.delivery.backport=true


### PR DESCRIPTION
https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory