### PR TITLE
CSI-3595: Remove https from artifactory url for docker login

### DIFF
--- a/build/ci/Jenkinsfile
+++ b/build/ci/Jenkinsfile
@@ -28,9 +28,11 @@ pipeline {
         stage ('Build and push images') {
             steps {
                 script {
-                    registryUrl = "https://${DOCKER_REGISTRY}"
-                    docker.withRegistry(registryUrl, registryCredentialsID) {
+                    registryUrl = "${DOCKER_REGISTRY}"
+                    withCredentials([usernamePassword(credentialsId: registryCredentialsID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                        sh 'docker login -u $USERNAME -p $PASSWORD ${DOCKER_REGISTRY}'
                         sh './build/ci/build_push_image.sh build/_output/reports/images_url'
+                        sh 'docker logout ${DOCKER_REGISTRY}'
                     }
                 }
             }


### PR DESCRIPTION
### Remove https from artifactory url for docker login

**Issue details**
Faced with `docker` login issue on power slave builder:
`docker login -u ******** -p ******** https://stg-artifactory.haifa.ibm.com:5030`
`Error: credentials key has https[s]:// prefix`

One direction was to remove the https from registry URL but this is not supported by the Jenkins docker plugin:
`java.net.MalformedURLException: unknown protocol: stg-artifactory.haifa.ibm.com`