### PR TITLE
undo final 1.7.0 community olm ocp versions diff

### DIFF
--- a/deploy/olm-catalog/ibm-block-csi-operator-community/1.7.0/bundle-1.7.0.Dockerfile
+++ b/deploy/olm-catalog/ibm-block-csi-operator-community/1.7.0/bundle-1.7.0.Dockerfile
@@ -9,5 +9,5 @@ LABEL operators.operatorframework.io.bundle.package.v1=ibm-block-csi-operator-co
 
 COPY manifests /manifests/
 COPY metadata /metadata/
-LABEL com.redhat.openshift.versions="=v4.8"
+LABEL com.redhat.openshift.versions="v4.8"
 LABEL com.redhat.delivery.operator.bundle=true

--- a/deploy/olm-catalog/ibm-block-csi-operator-community/1.7.0/metadata/annotations.yaml
+++ b/deploy/olm-catalog/ibm-block-csi-operator-community/1.7.0/metadata/annotations.yaml
@@ -5,4 +5,4 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: ibm-block-csi-operator-community
-  com.redhat.openshift.versions: "=v4.8"
+  com.redhat.openshift.versions: "v4.8"


### PR DESCRIPTION
mistakes were made.
https://github.com/k8s-operatorhub/community-operators/pull/237 rejected
